### PR TITLE
[RSVP Confirmation] Skeleton of input from rsvp modal

### DIFF
--- a/src/app/components/modals/rsvp/rsvp-attendees.js
+++ b/src/app/components/modals/rsvp/rsvp-attendees.js
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 import cx from 'classnames';
 import '../../../../stylesheets/components/modals/rsvp/rsvp-attendees.css';
 
-import { updateAttendingStatus,
-         toggleEmailEditState } from '../../../actions/rsvp-attendees';
+import { updateAttendingStatus } from '../../../actions/rsvp-attendees';
 
 import Avatar from 'material-ui/Avatar';
 import Checkbox from 'material-ui/Checkbox';

--- a/src/app/components/modals/rsvp/rsvp-attendees.js
+++ b/src/app/components/modals/rsvp/rsvp-attendees.js
@@ -87,7 +87,7 @@ class RsvpAttendees extends Component {
                   id={user.id}
                   key={index}
                 />
-              )
+              );
             })
           }
         </ul>

--- a/src/app/components/rsvp-confirmation.js
+++ b/src/app/components/rsvp-confirmation.js
@@ -36,6 +36,11 @@ function AttendeeList({
   );
 }
 
+AttendeeList.propTypes = {
+  subheader: PropTypes.string.isRequired,
+  users: PropTypes.array.isRequired,
+};
+
 function Lodging({ userGroup }) {
   const {
     lodging_friday,
@@ -72,6 +77,10 @@ function Lodging({ userGroup }) {
     </div>
   );
 }
+
+Lodging.propTypes = {
+  userGroup: PropTypes.object.isRequired,
+};
 
 export default class RsvpConfirmation extends Component {
   componentWillMount() {

--- a/src/app/components/rsvp-confirmation.js
+++ b/src/app/components/rsvp-confirmation.js
@@ -1,41 +1,134 @@
 import React, { Component, PropTypes } from 'react';
+import {List, ListItem} from 'material-ui/List';
+import Subheader from 'material-ui/Subheader';
+import Divider from 'material-ui/Divider';
+import Avatar from 'material-ui/Avatar';
+import FlatButton from 'material-ui/FlatButton';
+
+function AttendeeList({
+  subheader,
+  users,
+}) {
+  return (
+    <List>
+      <Subheader>{subheader}</Subheader>
+      {
+        users.map((user) => {
+          const initial = user.first_name[0].toUpperCase();
+          return (
+            <ListItem
+              leftAvatar={
+                  <Avatar
+                    backgroundColor="#44a5c9"
+                    size={50}
+                  >
+                  {initial}
+                </Avatar>
+              }
+              primaryText={`${user.first_name} ${user.last_name}`}
+              secondaryText={user.email}
+              key={user.id}
+            />
+          );
+        })
+      }
+    </List>
+  );
+}
+
+function Lodging({ userGroup }) {
+  const {
+    lodging_friday,
+    lodging_saturday,
+    lodging_sunday,
+  } = userGroup;
+  const lodgingDays = [lodging_friday, lodging_saturday, lodging_sunday];
+  const requestedLodgingDays = lodgingDays.filter((day) => { return day });
+
+  if (requestedLodgingDays.length > 0) {
+    return (
+      <div>
+        You are requesting lodging for:
+        <ul>
+          {lodging_friday && <li>Friday, Sept 01</li>}
+          {lodging_saturday && <li>Saturday, Sept 02 <b>(Wedding day)</b></li>}
+          {lodging_sunday && <li>Sunday, Sept 03</li>}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="error">
+        You are <b>not</b> requesting on-site lodging. There are many other options
+        nearby such as:
+      </p>
+      <ul>
+        <li>Example 1: Pine lodge</li>
+        <li>Example 2:</li>
+        <li>some other place</li>
+      </ul>
+    </div>
+  );
+}
 
 export default class RsvpConfirmation extends Component {
-
-  constructor(props) {
-    super(props);
-    // TODO(Jessica) move this to constructor
-    const { users } = props;
-    this._totalAttendees = -1;
-    if (users.length > 0) {
-      this._totalAttendees = props.users.reduce((totalAttendees, user) => {
-        return totalAttendees + user.is_attending;
-      });
+  componentWillMount() {
+    const { users, onRouteToHomepage } = this.props;
+    if (users.length === 0) {
+      onRouteToHomepage();
     }
   }
 
   render() {
+    const { userGroup, users, onRsvpClick } = this.props;
+    if (users.length === 0) return null;
+
+    const totalAttendees = users
+      .map(user => user.is_attending)
+      .reduce(function(a, b) { return a + b });
+    const isAnyoneAttending = totalAttendees > 0;
+
 
     return (
       <section className="rsvp-confirmation">
-        <p>{this._totalAttendees > 0 ? "We look forward to seeing you!" : "We will miss you!"}</p>
+        <h1>{isAnyoneAttending ? "We look forward to seeing you!" : "We will miss you!"}</h1>
 
         <h2>Here’s a confirmation of what you told us:</h2>
 
-        Want to change something?
-        <button
-          className="rsvp-button"
-          onClick={this.props.onRsvpClick}
+        <AttendeeList
+          subheader="Attending"
+          users={users.filter((user) => { return user.is_attending })}
+        />
+        <Divider />
+        <AttendeeList
+          subheader="Not Attending"
+          users={users.filter((user) => { return !user.is_attending })}
+        />
+
+        {isAnyoneAttending &&
+          <div>
+            <Divider />
+            This is a destination wedding north of Lake Tahoe, California.
+            <Lodging userGroup={userGroup} />
+          </div>
+        }
+
+        <h3>Want to change something?</h3>
+        <FlatButton
+          onClick={onRsvpClick}
         >
           Edit your RSVP
-        </button>
+        </FlatButton>
       </section>
     );
   }
 }
 
 RsvpConfirmation.propTypes = {
-  onRsvpClick: PropTypes.func.isRequired,
   userGroup: PropTypes.object.isRequired,
   users: PropTypes.array.isRequired,
+  onRsvpClick: PropTypes.func.isRequired,
+  onRouteToHomepage: PropTypes.func.isRequired,
 };

--- a/src/app/containers/dialog.js
+++ b/src/app/containers/dialog.js
@@ -25,7 +25,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(hideModal());
     },
     onRouteToConfirmation: () => {
-      dispatch(push('/rsvp'));
+      dispatch(push('/rsvp-confirmation'));
     },
   };
 };

--- a/src/app/containers/rsvp-confirmation.js
+++ b/src/app/containers/rsvp-confirmation.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 import Content from '../components/rsvp-confirmation';
 import { showRsvpPasscodeModal } from '../actions/show-rsvp-modal';
 
@@ -18,6 +19,9 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onRsvpClick: (code) => {
       dispatch(showRsvpPasscodeModal());
+    },
+    onRouteToHomepage: () => {
+      dispatch(push('/'));
     },
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ ReactDOM.render(
   <Router history={browserHistory} onUpdate={logPageView}>
     <Route path="/" component={Application}>
       <IndexRoute component={Homepage} />
-      <Route path="rsvp" component={RsvpConfirmation} />
+      <Route path="rsvp-confirmation" component={RsvpConfirmation} />
     </Route>
   </Router>,
   document.getElementById('root')


### PR DESCRIPTION
to: @lxwyndxl 

- skeleton of content confirming RSVP info
- checks for users (cannot come to /rsvp-confirmation directly) and reroutes to home if no users
- changed route from /rsvp to rsvp-confirmation

<img width="1439" alt="screen shot 2016-10-30 at 11 54 07 pm" src="https://cloud.githubusercontent.com/assets/1672947/19846445/8fe93d8e-9efc-11e6-9622-b2cfae1e3ce8.png">
